### PR TITLE
set_solout for stop function

### DIFF
--- a/examples/kepler_orbit.rs
+++ b/examples/kepler_orbit.rs
@@ -30,7 +30,7 @@ fn main() {
     );
 
     let mut stepper = Dopri5::new(system, 0.0, 5.0 * period, 60.0, y0, 1.0e-10, 1.0e-10);
-    stepper.set_solout(|_,y| { y[0] > 25500. });
+    stepper.set_solout(|_t,y,_dy| { y[0] > 25500. });
     let res = stepper.integrate();
 
     // Handle result

--- a/examples/kepler_orbit.rs
+++ b/examples/kepler_orbit.rs
@@ -30,6 +30,7 @@ fn main() {
     );
 
     let mut stepper = Dopri5::new(system, 0.0, 5.0 * period, 60.0, y0, 1.0e-10, 1.0e-10);
+    stepper.set_solout(|_,y| { y[0] > 25500. });
     let res = stepper.integrate();
 
     // Handle result

--- a/examples/kepler_orbit.rs
+++ b/examples/kepler_orbit.rs
@@ -30,7 +30,8 @@ fn main() {
     );
 
     let mut stepper = Dopri5::new(system, 0.0, 5.0 * period, 60.0, y0, 1.0e-10, 1.0e-10);
-    stepper.set_solout(|_t,y,_dy| { y[0] > 25500. });
+    // Stop the integration if x exceeds 25,500 km.
+    // stepper.set_solout(|_t,y,_dy| { y[0] > 25500. });
     let res = stepper.integrate();
 
     // Handle result

--- a/src/dop853.rs
+++ b/src/dop853.rs
@@ -54,6 +54,24 @@ use na;
 use std::f64;
 use std::f64::EPSILON;
 
+trait DefaultController {
+    fn default(x: f64, x_end: f64) -> Self;
+}
+
+impl DefaultController for Controller {
+    fn default(x: f64, x_end: f64) -> Self {
+        let alpha = 1.0 / 8.0;
+        Controller::new(
+            alpha,
+            0.0,
+            6.0,
+            0.333,
+            x_end - x,
+            0.9,
+            sign(1.0, x_end - x),
+        )
+    }
+}
 /// Structure containing the parameters for the numerical integration.
 pub struct Dop853<V>
 where
@@ -109,7 +127,6 @@ where
         rtol: f64,
         atol: f64,
     ) -> Dop853<V> {
-        let alpha = 1.0 / 8.0;
         Dop853 {
             f,
             x,
@@ -129,15 +146,7 @@ where
             n_max: 100000,
             n_stiff: 1000,
             coeffs: Dopri853::new(),
-            controller: Controller::new(
-                alpha,
-                0.0,
-                6.0,
-                0.333,
-                x_end - x,
-                0.9,
-                sign(1.0, x_end - x),
-            ),
+            controller: Controller::default(x, x_end),
             out_type: OutputType::Dense,
             rcont: [V::zero(); 8],
             stats: Stats::new(),

--- a/src/dopri5.rs
+++ b/src/dopri5.rs
@@ -429,9 +429,9 @@ where
                 self.x += self.h;
                 self.h_old = self.h;
 
-                self.solution_output(y_next);
+                self.solution_output(y_next, &k);
 
-                if (self.solout)(self.x, &self.y, &k[0]) {
+                if (self.solout)(self.x, &self.y_out.last().unwrap(), &k[0]) {
                     last = true;
                 }
 
@@ -448,7 +448,7 @@ where
         Ok(self.stats)
     }
 
-    fn solution_output(&mut self, y_next: V) {
+    fn solution_output(&mut self, y_next: V, k: &Vec<V>) {
         if self.out_type == OutputType::Dense {
             while self.xd.abs() <= self.x.abs() {
                 if self.x_old.abs() <= self.xd.abs() && self.x.abs() >= self.xd.abs() {
@@ -465,6 +465,9 @@ where
                                 * na::convert(theta),
                     );
                     self.xd += self.dx;
+                    if (self.solout)(self.x, &self.y_out.last().unwrap(), &k[0]) {
+                        break;
+                    }
                 }
             }
         } else {

--- a/src/dopri5.rs
+++ b/src/dopri5.rs
@@ -101,7 +101,7 @@ where
     out_type: OutputType,
     rcont: [V; 5],
     stats: Stats,
-    solout: fn(f64, &V) -> bool,
+    solout: fn(f64, &V, &V) -> bool,
 }
 
 impl<V> Dopri5<V>
@@ -152,7 +152,7 @@ where
             out_type: OutputType::Dense,
             rcont: [V::zero(); 5],
             stats: Stats::new(),
-            solout: |_, _| { false },
+            solout: |_, _, _| { false },
         }
     }
 
@@ -227,7 +227,7 @@ where
             out_type,
             rcont: [V::zero(); 5],
             stats: Stats::new(),
-            solout: |_, _| { false },
+            solout: |_, _, _| { false },
         }
     }
 
@@ -287,7 +287,7 @@ where
     }
 
     /// Set stop function will be called at every successful integration step.
-    pub fn set_solout(&mut self, solout: fn(f64, &V) -> bool) {
+    pub fn set_solout(&mut self, solout: fn(f64, &V, &V) -> bool) {
         self.solout = solout;
     }
 
@@ -431,7 +431,7 @@ where
 
                 self.solution_output(y_next);
 
-                if (self.solout)(self.x, &self.y) {
+                if (self.solout)(self.x, &self.y, &k[0]) {
                     last = true;
                 }
 


### PR DESCRIPTION
I've added simple `set_solout` function that take fn/closure for Dopri5 and doesn't break existent API.

This closes #1 for me.