### PR TITLE
Adds support for DVector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
+name = "bytemuck"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72957246c41db82b8ef88a5486143830adeb8227ef9837740bdec67724cf2c5b"
+
+[[package]]
 name = "matrixmultiply"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -28,9 +34,9 @@ dependencies = [
 
 [[package]]
 name = "nalgebra"
-version = "0.27.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "462fffe4002f4f2e1f6a9dcf12cc1a6fc0e15989014efc02a941d3e0f5dc2120"
+checksum = "d506eb7e08d6329505faa8a3a00a5dcc6de9f76e0c77e4b75763ae3c770831ff"
 dependencies = [
  "approx",
  "matrixmultiply",
@@ -38,7 +44,7 @@ dependencies = [
  "num-complex",
  "num-rational",
  "num-traits",
- "simba",
+ "simba 0.6.0",
  "typenum",
 ]
 
@@ -98,7 +104,7 @@ version = "0.3.3"
 dependencies = [
  "nalgebra",
  "num-traits",
- "simba",
+ "simba 0.5.1",
  "thiserror",
 ]
 
@@ -133,6 +139,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
+name = "safe_arch"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "794821e4ccb0d9f979512f9c1973480123f9bd62a90d74ab0f9426fcf8f4a529"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "simba"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -142,6 +157,19 @@ dependencies = [
  "num-complex",
  "num-traits",
  "paste",
+]
+
+[[package]]
+name = "simba"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0b7840f121a46d63066ee7a99fc81dcabbc6105e437cae43528cea199b5a05f"
+dependencies = [
+ "approx",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "wide",
 ]
 
 [[package]]
@@ -186,3 +214,13 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "wide"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd89cf484471f953ee84f07c0dff0ea20e9ddf976f03cabdf5dda48b221f22e7"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["science"]
 license = "BSD-3-Clause"
 
 [dependencies]
-nalgebra = "0.27.1"
+nalgebra = "0.29.0"
 num-traits = "0.2.14"
 simba = "0.5.1"
 thiserror = "1.0.25"

--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ The numerical integration methods implemented in the crate support multi-dimensi
 type State = Vector3<f64>;
 ```
 
-The state representation of the system is based on the SVector&lt;T,D&gt; structure defined in the [nalgebra](http://nalgebra.org/) crate. For convenience, ode-solvers re-exports six types to work with systems of dimension 1 to 6: Vector1&lt;T&gt;,..., Vector6&lt;T&gt;. For higher dimensions, the user should import the nalgebra crate and define a SVector&lt;T,D&gt;  where the second type parameter of SVector is a dimension. Note that the type T must be f64. For instance, for a 9-dimensional system, one would have:
+The state representation of the system is based on the SVector&lt;T,D&gt; structure defined in the [nalgebra](https://nalgebra.org/) crate. For convenience, ode-solvers re-exports six types to work with systems of dimension 1 to 6: Vector1&lt;T&gt;,..., Vector6&lt;T&gt;. For higher dimensions, the user should import the nalgebra crate and define a SVector&lt;T,D&gt;  where the second type parameter of SVector is a dimension. Note that the type T must be f64. For instance, for a 9-dimensional system, one would have:
 
 ```rust
 type State = SVector<f64, 9>;
 ```
 
-Alternativly, one can also use the DVector structure from the [nalgebra](http://nalgebra.org/) as the state representation. When using a DVector, the number of rows in the DVector defines the dimension of the system.
+Alternativly, one can also use the DVector&lt;T&gt; structure from the [nalgebra](https://nalgebra.org/) crate as the state representation. When using a DVector&lt;T&gt;, the number of rows in the DVector&lt;T&gt; defines the dimension of the system.
 
 ```rust
 type State = DVector<f64>;

--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ The state representation of the system is based on the SVector&lt;T,D&gt; struct
 type State = SVector<f64, 9>;
 ```
 
+Alternativly, one can also use the DVector structure from the [nalgebra](http://nalgebra.org/) as the state representation. When using a DVector, the number of rows in the DVector defines the dimension of the system.
+
+```rust
+type State = DVector<f64>;
+```
 
 
 ## System definition

--- a/examples/kepler_orbit_dvector.rs
+++ b/examples/kepler_orbit_dvector.rs
@@ -1,0 +1,86 @@
+// The equations of motion describing the motion of a spacecraft on a Kepler
+// orbit are integrated using Dopri5.
+
+use ode_solvers::dopri5::*;
+use ode_solvers::*;
+
+type State = DVector<f64>;
+type Time = f64;
+
+use std::{f64::consts::PI, fs::File, io::Write, path::Path};
+
+fn main() {
+    // Create the structure containing the ODEs.
+    let system = KeplerOrbit { mu: 398600.435436 };
+
+    let a: f64 = 20000.0;
+    let period = 2.0 * PI * (a.powi(3) / system.mu).sqrt();
+
+    // Orbit with: a = 20000km, e = 0.7, i = 35 deg, raan = 100 deg, arg_per = 65 deg, true_an = 30 deg.
+    let y0 = State::from(vec![
+        -5007.248417988539,
+        -1444.918140151374,
+        3628.534606178356,
+        0.717716656891,
+        -10.224093784269,
+        0.748229399696,
+    ]);
+
+    // Create a stepper and run the integration.
+    let mut stepper = Dopri5::new(system, 0.0, 5.0 * period, 60.0, y0, 1.0e-10, 1.0e-10);
+    let res = stepper.integrate();
+
+    // Handle result.
+    match res {
+        Ok(stats) => {
+            println!("{}", stats);
+            let path = Path::new("./outputs/kepler_orbit_dopri5_dvector.dat");
+            save(stepper.x_out(), stepper.y_out(), path);
+            println!("Results saved in: {:?}", path);
+        }
+        Err(e) => println!("An error occured: {}", e),
+    }
+}
+
+struct KeplerOrbit {
+    mu: f64,
+}
+
+impl ode_solvers::System<State> for KeplerOrbit {
+    // Equations of motion of the system
+    fn system(&self, _t: Time, y: &State, dy: &mut State) {
+        let r = (y[0] * y[0] + y[1] * y[1] + y[2] * y[2]).sqrt();
+
+        dy[0] = y[3];
+        dy[1] = y[4];
+        dy[2] = y[5];
+        dy[3] = -self.mu * y[0] / r.powi(3);
+        dy[4] = -self.mu * y[1] / r.powi(3);
+        dy[5] = -self.mu * y[2] / r.powi(3);
+    }
+
+    // Stop the integration if x exceeds 25,500 km. Optional
+    // fn solout(&mut self, _t: Time, y: &State, _dy: &State) -> bool {
+    // y[0] > 25500.
+    // }
+}
+
+pub fn save(times: &Vec<Time>, states: &Vec<State>, filename: &Path) {
+    // Create or open file
+    let mut buf = match File::create(filename) {
+        Err(e) => {
+            println!("Could not open file. Error: {:?}", e);
+            return;
+        }
+        Ok(buf) => buf,
+    };
+
+    // Write time and state vector in a csv format
+    for (i, state) in states.iter().enumerate() {
+        buf.write_fmt(format_args!("{}", times[i])).unwrap();
+        for val in state.iter() {
+            buf.write_fmt(format_args!(", {}", val)).unwrap();
+        }
+        buf.write_fmt(format_args!("\n")).unwrap();
+    }
+}

--- a/examples/three_body_system_dvector.rs
+++ b/examples/three_body_system_dvector.rs
@@ -1,0 +1,73 @@
+use ode_solvers::dop853::*;
+use ode_solvers::*;
+
+// Define type aliases for the state and time types
+type State = DVector<f64>;
+type Time = f64;
+
+use std::{fs::File, io::Write, path::Path};
+
+fn main() {
+    // Create the structure containing the problem specific constant and equations.
+    let system = ThreeBodyProblem {
+        mu: 0.012300118882173,
+    };
+
+    // Initial state.
+    let y0 = State::from(vec![-0.271, -0.42, 0.0, 0.3, -1.0, 0.0]);
+
+    // Create a stepper and run the integration.
+    let mut stepper = Dop853::new(system, 0.0, 150.0, 0.002, y0, 1.0e-14, 1.0e-14);
+    let res = stepper.integrate();
+
+    // Handle result
+    match res {
+        Ok(stats) => {
+            println!("{}", stats);
+            let path = Path::new("./outputs/three_body_dop853_dvector.dat");
+            save(stepper.x_out(), stepper.y_out(), path);
+            println!("Results saved in: {:?}", path);
+        }
+        Err(e) => println!("An error occured: {}", e),
+    }
+}
+
+struct ThreeBodyProblem {
+    mu: f64,
+}
+
+impl ode_solvers::System<State> for ThreeBodyProblem {
+    fn system(&self, _t: Time, y: &State, dy: &mut State) {
+        let d = ((y[0] + self.mu).powi(2) + y[1].powi(2) + y[2].powi(2)).sqrt();
+        let r = ((y[0] - 1.0 + self.mu).powi(2) + y[1].powi(2) + y[2].powi(2)).sqrt();
+
+        dy[0] = y[3];
+        dy[1] = y[4];
+        dy[2] = y[5];
+        dy[3] = y[0] + 2.0 * y[4]
+            - (1.0 - self.mu) * (y[0] + self.mu) / d.powi(3)
+            - self.mu * (y[0] - 1.0 + self.mu) / r.powi(3);
+        dy[4] =
+            -2.0 * y[3] + y[1] - (1.0 - self.mu) * y[1] / d.powi(3) - self.mu * y[1] / r.powi(3);
+        dy[5] = -(1.0 - self.mu) * y[2] / d.powi(3) - self.mu * y[2] / r.powi(3);
+    }
+}
+
+pub fn save(times: &Vec<Time>, states: &Vec<State>, filename: &Path) {
+    // Create or open file
+    let mut buf = match File::create(filename) {
+        Err(e) => {
+            println!("Could not open file. Error: {:?}", e);
+            return;
+        }
+        Ok(buf) => buf,
+    };
+    // Write time and state in a csv format
+    for (i, state) in states.iter().enumerate() {
+        buf.write_fmt(format_args!("{}", times[i])).unwrap();
+        for val in state.iter() {
+            buf.write_fmt(format_args!(", {}", val)).unwrap();
+        }
+        buf.write_fmt(format_args!("\n")).unwrap();
+    }
+}

--- a/src/dop_shared.rs
+++ b/src/dop_shared.rs
@@ -31,7 +31,6 @@ pub enum IntegrationError {
     StiffnessDetected { x: f64 },
 }
 
-
 /// Contains some statistics of the integration.
 #[derive(Clone, Copy, Debug)]
 pub struct Stats {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,9 @@
 //! `ode-solvers` is a collection of numerical methods to solve ordinary differential equations (ODEs).
 
 // Re-export from external crate
-pub use crate::na::{DVector, SVector, Vector1, Vector2, Vector3, Vector4, Vector5, Vector6};
+pub use crate::na::{
+    DVector, OVector, SVector, Vector1, Vector2, Vector3, Vector4, Vector5, Vector6,
+};
 use nalgebra as na;
 
 // Declare modules

--- a/src/rk4.rs
+++ b/src/rk4.rs
@@ -2,13 +2,14 @@
 
 use crate::dop_shared::{IntegrationError, Stats, System};
 
-use nalgebra::{Scalar, SVector };
+use nalgebra::{allocator::Allocator, DefaultAllocator, Dim, OVector, Scalar};
 use num_traits::Zero;
 use simba::scalar::{ClosedAdd, ClosedMul, ClosedNeg, ClosedSub, SubsetOf};
 
 /// Structure containing the parameters for the numerical integration.
 pub struct Rk4<V, F>
-    where F: System<V>
+where
+    F: System<V>,
 {
     f: F,
     x: f64,
@@ -18,14 +19,16 @@ pub struct Rk4<V, F>
     half_step: f64,
     x_out: Vec<f64>,
     y_out: Vec<V>,
-    stats: Stats
+    stats: Stats,
 }
 
-impl<T, F, const N: usize> Rk4<SVector<T, N>, F>
-    where f64: From<T>,
-          T: Copy + SubsetOf<f64> + Scalar + ClosedAdd + ClosedMul + ClosedSub + ClosedNeg + Zero,
-          F: System<SVector<T, N>>,
-          SVector<T, N>: std::ops::Mul<f64, Output = SVector<T, N>>
+impl<T, D: Dim, F> Rk4<OVector<T, D>, F>
+where
+    f64: From<T>,
+    T: Copy + SubsetOf<f64> + Scalar + ClosedAdd + ClosedMul + ClosedSub + ClosedNeg + Zero,
+    F: System<OVector<T, D>>,
+    OVector<T, D>: std::ops::Mul<f64, Output = OVector<T, D>>,
+    DefaultAllocator: Allocator<T, D>,
 {
     /// Default initializer for the structure
     ///
@@ -37,7 +40,7 @@ impl<T, F, const N: usize> Rk4<SVector<T, N>, F>
     /// * `x_end`       - Final value of the independent variable
     /// * `step_size`   - Step size used in the method
     ///
-    pub fn new(f: F, x: f64, y: SVector<T, N>, x_end: f64, step_size: f64) -> Self {
+    pub fn new(f: F, x: f64, y: OVector<T, D>, x_end: f64, step_size: f64) -> Self {
         Rk4 {
             f,
             x,
@@ -47,7 +50,7 @@ impl<T, F, const N: usize> Rk4<SVector<T, N>, F>
             half_step: step_size / 2.,
             x_out: Vec::new(),
             y_out: Vec::new(),
-            stats: Stats::new()
+            stats: Stats::new(),
         }
     }
 
@@ -55,15 +58,14 @@ impl<T, F, const N: usize> Rk4<SVector<T, N>, F>
     pub fn integrate(&mut self) -> Result<Stats, IntegrationError> {
         // Save initial values
         self.x_out.push(self.x);
-        self.y_out.push(self.y);
-
+        self.y_out.push(self.y.clone());
 
         let num_steps = ((self.x_end - self.x) / self.step_size).ceil() as usize;
         for _ in 0..num_steps {
             let (x_new, y_new) = self.step();
 
             self.x_out.push(x_new);
-            self.y_out.push(y_new);
+            self.y_out.push(y_new.clone());
 
             self.x = x_new;
             self.y = y_new;
@@ -75,16 +77,31 @@ impl<T, F, const N: usize> Rk4<SVector<T, N>, F>
     }
 
     /// Performs one step of the Runge-Kutta 4 method.
-    fn step(&self) -> (f64, SVector<T, N>) {
-        let mut k: Vec<SVector<T, N>> = vec![SVector::zero(); 4];
+    fn step(&self) -> (f64, OVector<T, D>) {
+        let (rows, cols) = self.y.shape_generic();
+        let mut k = vec![OVector::zeros_generic(rows, cols); 12];
 
         self.f.system(self.x, &self.y, &mut k[0]);
-        self.f.system(self.x + self.half_step, &(self.y + k[0] * self.half_step), &mut k[1]);
-        self.f.system(self.x + self.half_step, &(self.y + k[1] * self.half_step), &mut k[2]);
-        self.f.system(self.x + self.step_size, &(self.y + k[2] * self.step_size), &mut k[3]);
+        self.f.system(
+            self.x + self.half_step,
+            &(self.y.clone() + k[0].clone() * self.half_step),
+            &mut k[1],
+        );
+        self.f.system(
+            self.x + self.half_step,
+            &(self.y.clone() + k[1].clone() * self.half_step),
+            &mut k[2],
+        );
+        self.f.system(
+            self.x + self.step_size,
+            &(self.y.clone() + k[2].clone() * self.step_size),
+            &mut k[3],
+        );
 
         let x_new = self.x + self.step_size;
-        let y_new = self.y + (k[0] + k[1] * 2.0 + k[2] * 2.0 + k[3]) * (self.step_size / 6.0);
+        let y_new = &self.y
+            + (k[0].clone() + k[1].clone() * 2.0 + k[2].clone() * 2.0 + k[3].clone())
+                * (self.step_size / 6.0);
         (x_new, y_new)
     }
 
@@ -94,40 +111,49 @@ impl<T, F, const N: usize> Rk4<SVector<T, N>, F>
     }
 
     /// Getter for the dependent variables' output.
-    pub fn y_out(&self) -> &Vec<SVector<T, N>> {
+    pub fn y_out(&self) -> &Vec<OVector<T, D>> {
         &self.y_out
     }
 }
 
-
 #[cfg(test)]
 mod tests {
-    use crate::{System, Vector1};
     use crate::rk4::Rk4;
+    use crate::{DVector, OVector, System, Vector1};
+    use nalgebra::{allocator::Allocator, DefaultAllocator, Dim};
 
     struct Test1 {}
-    impl System<Vector1<f64>> for Test1 {
-        fn system(&self, x: f64, y: &Vector1<f64>, dy: &mut Vector1<f64>) {
+    impl<D: Dim> System<OVector<f64, D>> for Test1
+    where
+        DefaultAllocator: Allocator<f64, D>,
+    {
+        fn system(&self, x: f64, y: &OVector<f64, D>, dy: &mut OVector<f64, D>) {
             dy[0] = (x - y[0]) / 2.;
         }
     }
 
     struct Test2 {}
-    impl System<Vector1<f64>> for Test2 {
-        fn system(&self, x: f64, y: &Vector1<f64>, dy: &mut Vector1<f64>) {
+    impl<D: Dim> System<OVector<f64, D>> for Test2
+    where
+        DefaultAllocator: Allocator<f64, D>,
+    {
+        fn system(&self, x: f64, y: &OVector<f64, D>, dy: &mut OVector<f64, D>) {
             dy[0] = -2. * x - y[0];
         }
     }
 
     struct Test3 {}
-    impl System<Vector1<f64>> for Test3 {
-        fn system(&self, x: f64, y: &Vector1<f64>, dy: &mut Vector1<f64>) {
+    impl<D: Dim> System<OVector<f64, D>> for Test3
+    where
+        DefaultAllocator: Allocator<f64, D>,
+    {
+        fn system(&self, x: f64, y: &OVector<f64, D>, dy: &mut OVector<f64, D>) {
             dy[0] = (5. * x * x - y[0]) / (x + y[0]).exp();
         }
     }
 
     #[test]
-    fn test_integrate_test1() {
+    fn test_integrate_test1_svector() {
         let system = Test1 {};
         let mut stepper = Rk4::new(system, 0., Vector1::new(1.), 0.2, 0.1);
         let _ = stepper.integrate();
@@ -138,9 +164,8 @@ mod tests {
         assert!((&y_out[2][0] - 0.91451).abs() < 1.0E-5);
     }
 
-
     #[test]
-    fn test_integrate_test2() {
+    fn test_integrate_test2_svector() {
         let system = Test2 {};
         let mut stepper = Rk4::new(system, 0., Vector1::new(-1.), 0.5, 0.1);
         let _ = stepper.integrate();
@@ -152,9 +177,44 @@ mod tests {
     }
 
     #[test]
-    fn test_integrate_test3() {
+    fn test_integrate_test3_svector() {
         let system = Test3 {};
         let mut stepper = Rk4::new(system, 0., Vector1::new(1.), 1., 0.1);
+        let _ = stepper.integrate();
+        let out = stepper.y_out();
+        assert!((&out[5][0] - 0.913059839).abs() < 1.0E-9);
+        assert!((&out[8][0] - 0.9838057659).abs() < 1.0E-9);
+        assert!((&out[10][0] - 1.0715783953).abs() < 1.0E-9);
+    }
+
+    #[test]
+    fn test_integrate_test1_dvector() {
+        let system = Test1 {};
+        let mut stepper = Rk4::new(system, 0., DVector::from(vec![1.]), 0.2, 0.1);
+        let _ = stepper.integrate();
+        let x_out = stepper.x_out();
+        let y_out = stepper.y_out();
+        assert!((*x_out.last().unwrap() - 0.2).abs() < 1.0E-8);
+        assert!((&y_out[1][0] - 0.95369).abs() < 1.0E-5);
+        assert!((&y_out[2][0] - 0.91451).abs() < 1.0E-5);
+    }
+
+    #[test]
+    fn test_integrate_test2_dvector() {
+        let system = Test2 {};
+        let mut stepper = Rk4::new(system, 0., DVector::from(vec![-1.]), 0.5, 0.1);
+        let _ = stepper.integrate();
+        let x_out = stepper.x_out();
+        let y_out = stepper.y_out();
+        assert!((*x_out.last().unwrap() - 0.5).abs() < 1.0E-8);
+        assert!((&y_out[3][0] + 0.82246).abs() < 1.0E-5);
+        assert!((&y_out[5][0] + 0.81959).abs() < 1.0E-5);
+    }
+
+    #[test]
+    fn test_integrate_test3_dvector() {
+        let system = Test3 {};
+        let mut stepper = Rk4::new(system, 0., DVector::from(vec![1.]), 1., 0.1);
         let _ = stepper.integrate();
         let out = stepper.y_out();
         assert!((&out[5][0] - 0.913059839).abs() < 1.0E-9);


### PR DESCRIPTION
By using OVector, we can generically define impl's for Dop853, Dopri5, and Rk4 for both DVector and SVector types.

Before
```rust
impl<T, F, const N: usize> Dop853<SVector<T, N>, F>
where
    f64: From<T>,
    T: Copy + SubsetOf<f64> + Scalar + ClosedAdd + ClosedMul + ClosedSub + Zero,
    F: System<SVector<T, N>>,
{
    // ...
}
```

After
```rust
impl<T, D: Dim, F> Dop853<OVector<T, D>, F>
where
    f64: From<T>,
    T: Copy + SubsetOf<f64> + Scalar + ClosedAdd + ClosedMul + ClosedSub + Zero,
    F: System<OVector<T, D>>,
    DefaultAllocator: Allocator<T, D>,
{
    // ...
}
```

This pull request also bumps nalgebra version to 0.29.0