### PR TITLE
Using Buffer for output writing.

### DIFF
--- a/examples/kepler_orbit.rs
+++ b/examples/kepler_orbit.rs
@@ -7,7 +7,7 @@ use ode_solvers::*;
 type State = Vector6<f64>;
 type Time = f64;
 
-use std::{f64::consts::PI, fs::File, io::Write, path::Path};
+use std::{f64::consts::PI, fs::File, io::BufWriter, io::Write, path::Path};
 
 fn main() {
     // Create the structure containing the ODEs.
@@ -67,13 +67,14 @@ impl ode_solvers::System<State> for KeplerOrbit {
 
 pub fn save(times: &Vec<Time>, states: &Vec<State>, filename: &Path) {
     // Create or open file
-    let mut buf = match File::create(filename) {
+    let file = match File::create(filename) {
         Err(e) => {
             println!("Could not open file. Error: {:?}", e);
             return;
         }
         Ok(buf) => buf,
     };
+    let mut buf = BufWriter::new(file);
 
     // Write time and state vector in a csv format
     for (i, state) in states.iter().enumerate() {
@@ -82,5 +83,8 @@ pub fn save(times: &Vec<Time>, states: &Vec<State>, filename: &Path) {
             buf.write_fmt(format_args!(", {}", val)).unwrap();
         }
         buf.write_fmt(format_args!("\n")).unwrap();
+    }
+    if let Err(e) = buf.flush() {
+        println!("Could not write to file. Error: {:?}", e);
     }
 }

--- a/examples/kepler_orbit_dvector.rs
+++ b/examples/kepler_orbit_dvector.rs
@@ -7,7 +7,7 @@ use ode_solvers::*;
 type State = DVector<f64>;
 type Time = f64;
 
-use std::{f64::consts::PI, fs::File, io::Write, path::Path};
+use std::{f64::consts::PI, fs::File, io::BufWriter, io::Write, path::Path};
 
 fn main() {
     // Create the structure containing the ODEs.
@@ -67,13 +67,14 @@ impl ode_solvers::System<State> for KeplerOrbit {
 
 pub fn save(times: &Vec<Time>, states: &Vec<State>, filename: &Path) {
     // Create or open file
-    let mut buf = match File::create(filename) {
+    let file = match File::create(filename) {
         Err(e) => {
             println!("Could not open file. Error: {:?}", e);
             return;
         }
         Ok(buf) => buf,
     };
+    let mut buf = BufWriter::new(file);
 
     // Write time and state vector in a csv format
     for (i, state) in states.iter().enumerate() {
@@ -82,5 +83,8 @@ pub fn save(times: &Vec<Time>, states: &Vec<State>, filename: &Path) {
             buf.write_fmt(format_args!(", {}", val)).unwrap();
         }
         buf.write_fmt(format_args!("\n")).unwrap();
+    }
+    if let Err(e) = buf.flush() {
+        println!("Could not write to file. Error: {:?}", e);
     }
 }

--- a/examples/lorenz.rs
+++ b/examples/lorenz.rs
@@ -3,7 +3,7 @@
 use ode_solvers::dop853::*;
 use ode_solvers::*;
 
-use std::{fs::File, io::Write, path::Path};
+use std::{fs::File, io::BufWriter, io::Write, path::Path};
 
 type State = Vector3<f64>;
 type Time = f64;
@@ -50,13 +50,14 @@ impl ode_solvers::System<State> for LorenzAttractor {
 
 pub fn save(times: &Vec<Time>, states: &Vec<State>, filename: &Path) {
     // Create or open file
-    let mut buf = match File::create(filename) {
+    let file = match File::create(filename) {
         Err(e) => {
             println!("Could not open file. Error: {:?}", e);
             return;
         }
         Ok(buf) => buf,
     };
+    let mut buf = BufWriter::new(file);
 
     // Write time and state vector in a csv format
     for (i, state) in states.iter().enumerate() {
@@ -65,5 +66,8 @@ pub fn save(times: &Vec<Time>, states: &Vec<State>, filename: &Path) {
             buf.write_fmt(format_args!(", {}", val)).unwrap();
         }
         buf.write_fmt(format_args!("\n")).unwrap();
+    }
+    if let Err(e) = buf.flush() {
+        println!("Could not write to file. Error: {:?}", e);
     }
 }

--- a/examples/three_body_system.rs
+++ b/examples/three_body_system.rs
@@ -5,7 +5,7 @@ use ode_solvers::*;
 type State = Vector6<f64>;
 type Time = f64;
 
-use std::{fs::File, io::Write, path::Path};
+use std::{fs::File, io::BufWriter, io::Write, path::Path};
 
 fn main() {
     // Create the structure containing the problem specific constant and equations.
@@ -55,19 +55,24 @@ impl ode_solvers::System<State> for ThreeBodyProblem {
 
 pub fn save(times: &Vec<Time>, states: &Vec<State>, filename: &Path) {
     // Create or open file
-    let mut buf = match File::create(filename) {
+    let file = match File::create(filename) {
         Err(e) => {
             println!("Could not open file. Error: {:?}", e);
             return;
         }
         Ok(buf) => buf,
     };
-    // Write time and state in a csv format
+    let mut buf = BufWriter::new(file);
+
+    // Write time and state vector in a csv format
     for (i, state) in states.iter().enumerate() {
         buf.write_fmt(format_args!("{}", times[i])).unwrap();
         for val in state.iter() {
             buf.write_fmt(format_args!(", {}", val)).unwrap();
         }
         buf.write_fmt(format_args!("\n")).unwrap();
+    }
+    if let Err(e) = buf.flush() {
+        println!("Could not write to file. Error: {:?}", e);
     }
 }

--- a/examples/three_body_system_dvector.rs
+++ b/examples/three_body_system_dvector.rs
@@ -5,7 +5,7 @@ use ode_solvers::*;
 type State = DVector<f64>;
 type Time = f64;
 
-use std::{fs::File, io::Write, path::Path};
+use std::{fs::File, io::BufWriter, io::Write, path::Path};
 
 fn main() {
     // Create the structure containing the problem specific constant and equations.
@@ -55,19 +55,24 @@ impl ode_solvers::System<State> for ThreeBodyProblem {
 
 pub fn save(times: &Vec<Time>, states: &Vec<State>, filename: &Path) {
     // Create or open file
-    let mut buf = match File::create(filename) {
+    let file = match File::create(filename) {
         Err(e) => {
             println!("Could not open file. Error: {:?}", e);
             return;
         }
         Ok(buf) => buf,
     };
-    // Write time and state in a csv format
+    let mut buf = BufWriter::new(file);
+
+    // Write time and state vector in a csv format
     for (i, state) in states.iter().enumerate() {
         buf.write_fmt(format_args!("{}", times[i])).unwrap();
         for val in state.iter() {
             buf.write_fmt(format_args!(", {}", val)).unwrap();
         }
         buf.write_fmt(format_args!("\n")).unwrap();
+    }
+    if let Err(e) = buf.flush() {
+        println!("Could not write to file. Error: {:?}", e);
     }
 }


### PR DESCRIPTION
I've been using this crate for a lorenz-96 system and noticed that the runtime is easily dominated by the time it takes to write the results into a file.
Given that you already named your variable buf and that other users will probably run into the same issue when 
starting at the examples, I just went ahead and added it to all examples.
It's not that necessary for the examples themselves and it's adding 5 lines per example, so feel free to reject it if you want 
to keep them minimal.
