### PR TITLE
Update documentation of solout

### DIFF
--- a/src/dop_shared.rs
+++ b/src/dop_shared.rs
@@ -7,7 +7,7 @@ use thiserror::Error;
 pub trait System<V> {
     /// System of ordinary differential equations.
     fn system(&self, x: f64, y: &V, dy: &mut V);
-    /// Stop function called at every successful integration step. The integration is stopped when this function returns true.
+    /// Stop function called at every successful integration step when using the dopri5 solver. The integration is stopped when this function returns true.
     fn solout(&mut self, _x: f64, _y: &V, _dy: &V) -> bool {
         false
     }


### PR DESCRIPTION
Hello, thanks for this nice crate :-) When playing around with the solvers, I found that the solout method is apparently only called when using the dopri5 solver. However, this is not mentioned in the documentation. Therefore I added a small addendum which hopefully clarifies this.

EDIT: If https://github.com/srenevey/ode-solvers/pull/12 is merged, this PR can be rejected.