### PR TITLE
Fix bug where final step wouldn't be computed if rejected by controller

### DIFF
--- a/src/dopri5.rs
+++ b/src/dopri5.rs
@@ -396,8 +396,11 @@ where
                     self.h_old = posneg * h_new;
                     return Ok(self.stats);
                 }
-            } else if self.stats.accepted_steps >= 1 {
-                self.stats.rejected_steps += 1;
+            } else {
+                last = false;
+                if self.stats.accepted_steps >= 1 {
+                    self.stats.rejected_steps += 1;
+                }
             }
             self.h = h_new;
         }


### PR DESCRIPTION
Ensure `last` is set to `false` if the last step is rejected by the controller. Previously, the last step would manually set `last` to `true` without regard to whether the controller ends up rejecting the step.