### PR TITLE
Move results out of Solver and use generic numeric code (select f32/f64)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ outputs
 .DS_Store
 .idea
 Cargo.lock
+.vscode

--- a/examples/bouncing_ball.rs
+++ b/examples/bouncing_ball.rs
@@ -7,12 +7,12 @@ use std::{fs::File, io::BufWriter, io::Write, path::Path};
 use ode_solvers::dop_shared::SolverResult;
 use ode_solvers::*;
 
-type State = Vector3<f64>; // stores location, velocity and time
-type Time = f64;
-type Result = SolverResult<State>;
+type State = Vector3<f32>; // stores location, velocity and time
+type Time = f32;
+type Result = SolverResult<Time, State>;
 
-const G: f64 = 9.81; // gravity constant on earth
-const BOUNCE: f64 = 0.75;
+const G: f32 = 9.81; // gravity constant on earth
+const BOUNCE: f32 = 0.75;
 const MAX_BOUNCES: u32 = 5;
 
 fn main() {
@@ -28,7 +28,7 @@ fn main() {
         // Create a stepper and run the integration.
         // Use comments to see differences with Dopri
         //let mut stepper = Dopri5::new(system, 0., 10.0, 0.01, y0, 1.0e-2, 1.0e-6);
-        let mut stepper = Rk4::new(system, 0.0, y0, 10.0, 0.01);
+        let mut stepper = Rk4::new(system, 0f32, y0, 10f32, 0.01f32);
         let res = stepper.integrate();
 
         // Handle result.
@@ -69,13 +69,13 @@ fn main() {
 
 struct BouncingBall;
 
-impl ode_solvers::System<State> for BouncingBall {
+impl ode_solvers::System<Time, State> for BouncingBall {
     fn system(&self, _t: Time, y: &State, dy: &mut State) {
         dy[0] = y[1]; // location is changed by v
-        dy[1] = -G; // v is changed by acc of gravity
+        dy[1] = -G as f32; // v is changed by acc of gravity
     }
 
-    fn solout(&mut self, _x: f64, y: &State, _dy: &State) -> bool {
+    fn solout(&mut self, _x: Time, y: &State, _dy: &State) -> bool {
         y[0] < 0.
     }
 }

--- a/examples/bouncing_ball.rs
+++ b/examples/bouncing_ball.rs
@@ -1,0 +1,105 @@
+// A bouncing ball example
+// This shows how to couple multiple calls of the ODE solver and move the ownership of the results to a custom data structure
+// This also useful for sequential simulation, e.g. for reactor cascades.
+
+use std::{fs::File, io::BufWriter, io::Write, path::Path};
+
+use ode_solvers::dop_shared::SolverResult;
+use ode_solvers::*;
+
+type State = Vector3<f64>; // stores location, velocity and time
+type Time = f64;
+type Result = SolverResult<State>;
+
+const G: f64 = 9.81; // gravity constant on earth
+const BOUNCE: f64 = 0.75;
+const MAX_BOUNCES: u32 = 5;
+
+fn main() {
+    // Initial state: At 10m with zero velocity
+    let mut y0 = State::new(10.0, 0., 0.);
+    let mut num_bounces = 0;
+    let mut combined_solver_results = Result::default();
+
+    while num_bounces < MAX_BOUNCES && y0[0] >= 0.001 {
+        // Create the structure containing the ODEs.
+        let system = BouncingBall;
+
+        // Create a stepper and run the integration.
+        // Use comments to see differences with Dopri
+        //let mut stepper = Dopri5::new(system, 0., 10.0, 0.01, y0, 1.0e-2, 1.0e-6);
+        let mut stepper = Rk4::new(system, 0.0, y0, 10.0, 0.01);
+        let res = stepper.integrate();
+
+        // Handle result.
+        match res {
+            Ok(stats) => println!("{}", stats),
+            Err(e) => println!("An error occured: {}", e),
+        }
+
+        num_bounces = num_bounces + 1;
+
+        // solout may not be called and therefore end not "smooth" when observing dense values with dopri5 or dop853
+        // therefore we seach for the point where the results turn zero
+        let (_, y_out) = stepper.results().get();
+        let f = y_out.iter().find(|y| y[0] <= 0.);
+        if f.is_none() {
+            // that should not happen...
+            break;
+        }
+
+        let last_state = f.unwrap();
+        println!("Last state: {:?}\n\n", last_state);
+
+        y0[0] = last_state[0].abs();
+        y0[1] = -1. * last_state[1] * BOUNCE;
+
+        // beware in the case of dopri5 or dop853 the results contain a lot of invalid data with y[0] < 0
+        combined_solver_results.append(stepper.into());
+    }
+
+    let path = Path::new("./outputs/bouncing_ball.dat");
+
+    save(
+        combined_solver_results.get().0,
+        combined_solver_results.get().1,
+        path,
+    );
+}
+
+struct BouncingBall;
+
+impl ode_solvers::System<State> for BouncingBall {
+    fn system(&self, _t: Time, y: &State, dy: &mut State) {
+        dy[0] = y[1]; // location is changed by v
+        dy[1] = -G; // v is changed by acc of gravity
+    }
+
+    fn solout(&mut self, _x: f64, y: &State, _dy: &State) -> bool {
+        y[0] < 0.
+    }
+}
+
+pub fn save(times: &Vec<Time>, states: &Vec<State>, filename: &Path) {
+    // Create or open file
+    let file = match File::create(filename) {
+        Err(e) => {
+            println!("Could not open file. Error: {:?}", e);
+            return;
+        }
+        Ok(buf) => buf,
+    };
+    let mut buf = BufWriter::new(file);
+
+    // Write time and state vector in a csv format
+    for (i, state) in states.iter().enumerate() {
+        buf.write_fmt(format_args!("{}", times[i])).unwrap();
+        for val in state.iter() {
+            buf.write_fmt(format_args!(", {}", val)).unwrap();
+        }
+        buf.write_fmt(format_args!("\n")).unwrap();
+    }
+    if let Err(e) = buf.flush() {
+        println!("Could not write to file. Error: {:?}", e);
+    }
+}

--- a/examples/bouncing_ball.rs
+++ b/examples/bouncing_ball.rs
@@ -1,6 +1,6 @@
 // A bouncing ball example
 // This shows how to couple multiple calls of the ODE solver and move the ownership of the results to a custom data structure
-// This also useful for sequential simulation, e.g. for reactor cascades.
+// This is also useful for sequential simulation, e.g. for reactor cascades.
 
 use std::{fs::File, io::BufWriter, io::Write, path::Path};
 
@@ -40,7 +40,7 @@ fn main() {
         num_bounces = num_bounces + 1;
 
         // solout may not be called and therefore end not "smooth" when observing dense values with dopri5 or dop853
-        // therefore we seach for the point where the results turn zero
+        // Therefore we seach for the point where the results turn zero
         let (_, y_out) = stepper.results().get();
         let f = y_out.iter().find(|y| y[0] <= 0.);
         if f.is_none() {
@@ -49,7 +49,7 @@ fn main() {
         }
 
         let last_state = f.unwrap();
-        println!("Last state: {:?}\n\n", last_state);
+        println!("Last state: {:?}", last_state);
 
         y0[0] = last_state[0].abs();
         y0[1] = -1. * last_state[1] * BOUNCE;

--- a/examples/chemical_reaction.rs
+++ b/examples/chemical_reaction.rs
@@ -27,7 +27,7 @@ fn main() {
 
 struct ChemicalReaction;
 
-impl ode_solvers::System<State> for ChemicalReaction {
+impl ode_solvers::System<f64, State> for ChemicalReaction {
     fn system(&self, _: Time, y: &State, dy: &mut State) {
         dy[0] = -0.04 * y[0] + 10000. * y[1] * y[2];
         dy[1] = 0.04 * y[0] - 10000. * y[1] * y[2] - 3. * 10_f64.powi(7) * y[1] * y[1];

--- a/examples/kepler_orbit.rs
+++ b/examples/kepler_orbit.rs
@@ -46,7 +46,7 @@ struct KeplerOrbit {
     mu: f64,
 }
 
-impl ode_solvers::System<State> for KeplerOrbit {
+impl ode_solvers::System<f64, State> for KeplerOrbit {
     // Equations of motion of the system
     fn system(&self, _t: Time, y: &State, dy: &mut State) {
         let r = (y[0] * y[0] + y[1] * y[1] + y[2] * y[2]).sqrt();

--- a/examples/kepler_orbit_dvector.rs
+++ b/examples/kepler_orbit_dvector.rs
@@ -46,7 +46,7 @@ struct KeplerOrbit {
     mu: f64,
 }
 
-impl ode_solvers::System<State> for KeplerOrbit {
+impl ode_solvers::System<f64, State> for KeplerOrbit {
     // Equations of motion of the system
     fn system(&self, _t: Time, y: &State, dy: &mut State) {
         let r = (y[0] * y[0] + y[1] * y[1] + y[2] * y[2]).sqrt();

--- a/examples/lorenz.rs
+++ b/examples/lorenz.rs
@@ -40,7 +40,7 @@ struct LorenzAttractor {
     rho: f64,
 }
 
-impl ode_solvers::System<State> for LorenzAttractor {
+impl ode_solvers::System<f64, State> for LorenzAttractor {
     fn system(&self, _t: Time, y: &State, dy: &mut State) {
         dy[0] = self.sigma * (y[1] - y[0]);
         dy[1] = y[0] * (self.rho - y[2]) - y[1];

--- a/examples/three_body_system.rs
+++ b/examples/three_body_system.rs
@@ -36,7 +36,7 @@ struct ThreeBodyProblem {
     mu: f64,
 }
 
-impl ode_solvers::System<State> for ThreeBodyProblem {
+impl ode_solvers::System<f64, State> for ThreeBodyProblem {
     fn system(&self, _t: Time, y: &State, dy: &mut State) {
         let d = ((y[0] + self.mu).powi(2) + y[1].powi(2) + y[2].powi(2)).sqrt();
         let r = ((y[0] - 1.0 + self.mu).powi(2) + y[1].powi(2) + y[2].powi(2)).sqrt();

--- a/examples/three_body_system_dvector.rs
+++ b/examples/three_body_system_dvector.rs
@@ -36,7 +36,7 @@ struct ThreeBodyProblem {
     mu: f64,
 }
 
-impl ode_solvers::System<State> for ThreeBodyProblem {
+impl ode_solvers::System<f64, State> for ThreeBodyProblem {
     fn system(&self, _t: Time, y: &State, dy: &mut State) {
         let d = ((y[0] + self.mu).powi(2) + y[1].powi(2) + y[2].powi(2)).sqrt();
         let r = ((y[0] - 1.0 + self.mu).powi(2) + y[1].powi(2) + y[2].powi(2)).sqrt();

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -1,19 +1,25 @@
 //! Adaptive step size control.
 
+use nalgebra::Scalar;
+use num_traits::{Float, FromPrimitive, NumCast, Zero};
+use simba::scalar::{ClosedAdd, ClosedDiv, ClosedMul, ClosedNeg, ClosedSub, SubsetOf};
+
+use crate::dop_shared::FloatNumber;
+
 /// Used for adaptive step size control
-pub struct Controller {
-    alpha: f64,
-    beta: f64,
-    facc1: f64,
-    facc2: f64,
-    fac_old: f64,
-    h_max: f64,
+pub struct Controller<T> {
+    alpha: T,
+    beta: T,
+    facc1: T,
+    facc2: T,
+    fac_old: T,
+    h_max: T,
     reject: bool,
-    safety_factor: f64,
-    posneg: f64,
+    safety_factor: T,
+    posneg: T,
 }
 
-impl Controller {
+impl<T: FloatNumber> Controller<T> {
     /// Creates a controller responsible for adaptive step size control.
     ///
     /// # Arguments
@@ -26,20 +32,20 @@ impl Controller {
     /// * `safety_factor`   - Safety factor of the PI controller
     ///
     pub fn new(
-        alpha: f64,
-        beta: f64,
-        fac_max: f64,
-        fac_min: f64,
-        h_max: f64,
-        safety_factor: f64,
-        posneg: f64,
-    ) -> Controller {
+        alpha: T,
+        beta: T,
+        fac_max: T,
+        fac_min: T,
+        h_max: T,
+        safety_factor: T,
+        posneg: T,
+    ) -> Controller<T> {
         Controller {
             alpha,
             beta,
-            facc1: 1.0 / fac_min,
-            facc2: 1.0 / fac_max,
-            fac_old: 1.0E-4,
+            facc1: T::from(1.0).unwrap() / fac_min,
+            facc2: T::from(1.0).unwrap() / fac_max,
+            fac_old: T::from(1.0E-4).unwrap(),
             h_max: h_max.abs(),
             reject: false,
             safety_factor,
@@ -48,15 +54,15 @@ impl Controller {
     }
 
     /// Determines if the step must be accepted or rejected and adapts the step size accordingly.
-    pub fn accept(&mut self, err: f64, h: f64, h_new: &mut f64) -> bool {
+    pub fn accept(&mut self, err: T, h: T, h_new: &mut T) -> bool {
         let fac11 = err.powf(self.alpha);
         let mut fac = fac11 * self.fac_old.powf(-self.beta);
         fac = (self.facc2).max((self.facc1).min(fac / self.safety_factor));
         *h_new = h / fac;
 
-        if err <= 1.0 {
+        if err <= T::from(1.0).unwrap() {
             // Accept step
-            self.fac_old = err.max(1.0E-4);
+            self.fac_old = err.max(T::from(1.0E-4).unwrap());
 
             if h_new.abs() > self.h_max {
                 *h_new = self.posneg * self.h_max;
@@ -76,7 +82,7 @@ impl Controller {
     }
 
     /// Returns the maximum step size allowed.
-    pub fn h_max(&self) -> f64 {
+    pub fn h_max(&self) -> T {
         self.h_max
     }
 }

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -38,7 +38,7 @@ impl<T: FloatNumber> Controller<T> {
         Controller {
             alpha,
             beta,
-            facc1: T::from(1.0).unwrap() / fac_min,
+            facc1: T::one() / fac_min,
             facc2: T::from(1.0).unwrap() / fac_max,
             fac_old: T::from(1.0E-4).unwrap(),
             h_max: h_max.abs(),

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -1,9 +1,4 @@
 //! Adaptive step size control.
-
-use nalgebra::Scalar;
-use num_traits::{Float, FromPrimitive, NumCast, Zero};
-use simba::scalar::{ClosedAdd, ClosedDiv, ClosedMul, ClosedNeg, ClosedSub, SubsetOf};
-
 use crate::dop_shared::FloatNumber;
 
 /// Used for adaptive step size control

--- a/src/dop853.rs
+++ b/src/dop853.rs
@@ -210,7 +210,8 @@ where
         }
 
         // Compute h0
-        let mut h0 = if d0 < T::from(1.0E-10).unwrap() || d1 < T::from(1.0E-10).unwrap() {
+        let tol = T::from(1.0E-10).unwrap();
+        let mut h0 = if d0 < tol || d1 < tol {
             T::from(1.0E-6).unwrap()
         } else {
             T::from(0.01).unwrap() * (d0 / d1).sqrt()
@@ -239,7 +240,7 @@ where
                 .unwrap()
                 .max(h0.abs() * T::from(1.0E-3).unwrap())
         } else {
-            (T::from(0.01).unwrap() / (d1.sqrt().max(d2))).powf(T::one() / T::from(8.0).unwrap())
+            (T::from(0.01).unwrap() / (d1.sqrt().max(d2))).powf(T::from(0.125).unwrap())
         };
 
         sign(

--- a/src/dop853.rs
+++ b/src/dop853.rs
@@ -4,52 +4,60 @@ use crate::butcher_tableau::dopri853;
 use crate::controller::Controller;
 use crate::dop_shared::*;
 
-use nalgebra::{allocator::Allocator, DefaultAllocator, Dim, OVector, Scalar};
-use num_traits::Zero;
-use simba::scalar::{ClosedAdd, ClosedMul, ClosedSub, SubsetOf, SupersetOf};
+use nalgebra::{allocator::Allocator, DefaultAllocator, Dim, OVector};
 
-trait DefaultController {
-    fn default(x: f64, x_end: f64) -> Self;
+trait DefaultController<T: FloatNumber> {
+    fn default(x: T, x_end: T) -> Self;
 }
 
-impl DefaultController for Controller {
-    fn default(x: f64, x_end: f64) -> Self {
-        let alpha = 1.0 / 8.0;
-        Controller::new(alpha, 0.0, 6.0, 0.333, x_end - x, 0.9, sign(1.0, x_end - x))
+impl<T: FloatNumber> DefaultController<T> for Controller<T> {
+    fn default(x: T, x_end: T) -> Self {
+        let alpha = T::one() / T::from(8.0).unwrap();
+        Controller::new(
+            alpha,
+            T::zero(),
+            T::from(6.0).unwrap(),
+            T::from(0.333).unwrap(),
+            x_end - x,
+            T::from(0.9).unwrap(),
+            sign(T::one(), x_end - x),
+        )
     }
 }
 /// Structure containing the parameters for the numerical integration.
-pub struct Dop853<V, F>
+pub struct Dop853<T, V, F>
 where
-    F: System<V>,
+    T: FloatNumber,
+    F: System<T, V>,
 {
     f: F,
-    x: f64,
-    x0: f64,
-    x_old: f64,
-    x_end: f64,
-    xd: f64,
-    dx: f64,
+    x: T,
+    x0: T,
+    x_old: T,
+    x_end: T,
+    xd: T,
+    dx: T,
     y: V,
-    rtol: f64,
-    atol: f64,
-    results: SolverResult<V>,
-    uround: f64,
-    h: f64,
-    h_old: f64,
+    rtol: T,
+    atol: T,
+    results: SolverResult<T, V>,
+    uround: T,
+    h: T,
+    h_old: T,
     n_max: u32,
     n_stiff: u32,
-    controller: Controller,
+    controller: Controller<T>,
     out_type: OutputType,
     rcont: [V; 8],
     stats: Stats,
 }
 
-impl<T, D: Dim, F> Dop853<OVector<T, D>, F>
+impl<T, D: Dim, F> Dop853<T, OVector<T, D>, F>
 where
     f64: From<T>,
-    T: Copy + SubsetOf<f64> + Scalar + ClosedAdd + ClosedMul + ClosedSub + Zero,
-    F: System<OVector<T, D>>,
+    T: FloatNumber,
+    F: System<T, OVector<T, D>>,
+    OVector<T, D>: std::ops::Mul<T, Output = OVector<T, D>>,
     DefaultAllocator: Allocator<T, D>,
 {
     /// Default initializer for the structure.
@@ -64,7 +72,7 @@ where
     /// * `rtol`    - Relative tolerance used in the computation of the adaptive step size
     /// * `atol`    - Absolute tolerance used in the computation of the adaptive step size
     ///
-    pub fn new(f: F, x: f64, x_end: f64, dx: f64, y: OVector<T, D>, rtol: f64, atol: f64) -> Self {
+    pub fn new(f: F, x: T, x_end: T, dx: T, y: OVector<T, D>, rtol: T, atol: T) -> Self {
         let (rows, cols) = y.shape_generic();
         Self {
             f,
@@ -78,9 +86,9 @@ where
             rtol,
             atol,
             results: SolverResult::default(),
-            uround: f64::EPSILON,
-            h: 0.0,
-            h_old: 0.0,
+            uround: T::from(f64::EPSILON).unwrap(),
+            h: T::zero(),
+            h_old: T::zero(),
             n_max: 100000,
             n_stiff: 1000,
             controller: Controller::default(x, x_end),
@@ -123,23 +131,23 @@ where
     #[allow(clippy::too_many_arguments)]
     pub fn from_param(
         f: F,
-        x: f64,
-        x_end: f64,
-        dx: f64,
+        x: T,
+        x_end: T,
+        dx: T,
         y: OVector<T, D>,
-        rtol: f64,
-        atol: f64,
-        safety_factor: f64,
-        beta: f64,
-        fac_min: f64,
-        fac_max: f64,
-        h_max: f64,
-        h: f64,
+        rtol: T,
+        atol: T,
+        safety_factor: T,
+        beta: T,
+        fac_min: T,
+        fac_max: T,
+        h_max: T,
+        h: T,
         n_max: u32,
         n_stiff: u32,
         out_type: OutputType,
     ) -> Self {
-        let alpha = 1.0 / 8.0 - beta * 0.2;
+        let alpha = T::one() / T::from(8.0).unwrap() - beta * T::from(0.2).unwrap();
         let (rows, cols) = y.shape_generic();
         Self {
             f,
@@ -153,7 +161,7 @@ where
             rtol,
             atol,
             results: SolverResult::default(),
-            uround: f64::EPSILON,
+            uround: T::from(f64::EPSILON).unwrap(),
             h,
             h_old: h,
             n_max,
@@ -165,7 +173,7 @@ where
                 fac_min,
                 h_max,
                 safety_factor,
-                sign(1.0, x_end - x),
+                sign(T::one(), x_end - x),
             ),
             out_type,
             rcont: [
@@ -183,57 +191,59 @@ where
     }
 
     /// Compute the initial stepsize
-    fn hinit(&self) -> f64 {
+    fn hinit(&self) -> T {
         let (rows, cols) = self.y.shape_generic();
         let mut f0 = OVector::zeros_generic(rows, cols);
         self.f.system(self.x, &self.y, &mut f0);
-        let posneg = sign(1.0, self.x_end - self.x);
+        let posneg = sign(T::one(), self.x_end - self.x);
 
         // Compute the norm of y0 and f0
         let dim = rows.value();
-        let mut d0 = 0.0;
-        let mut d1 = 0.0;
+        let mut d0 = T::zero();
+        let mut d1 = T::zero();
         for i in 0..dim {
-            let y_i = f64::from(self.y[i]);
+            let y_i = self.y[i];
             let sci = self.atol + y_i.abs() * self.rtol;
             d0 += (y_i / sci) * (y_i / sci);
-            let f0_i = f64::from(f0[i]);
+            let f0_i = f0[i];
             d1 += (f0_i / sci) * (f0_i / sci);
         }
 
         // Compute h0
-        let mut h0 = if d0 < 1.0E-10 || d1 < 1.0E-10 {
-            1.0E-6
+        let mut h0 = if d0 < T::from(1.0E-10).unwrap() || d1 < T::from(1.0E-10).unwrap() {
+            T::from(1.0E-6).unwrap()
         } else {
-            0.01 * (d0 / d1).sqrt()
+            T::from(0.01).unwrap() * (d0 / d1).sqrt()
         };
 
         h0 = h0.min(self.controller.h_max());
         h0 = sign(h0, posneg);
 
-        let y1 = &self.y + &f0 * h0.to_subset().unwrap();
+        let y1 = &self.y + &f0 * h0;
         let mut f1 = OVector::zeros_generic(rows, cols);
         self.f.system(self.x + h0, &y1, &mut f1);
 
         // Compute the norm of f1-f0 divided by h0
-        let mut d2: f64 = 0.0;
+        let mut d2 = T::zero();
         for i in 0..dim {
-            let f0_i = f64::from(f0[i]);
-            let f1_i = f64::from(f1[i]);
-            let y_i = f64::from(self.y[i]);
-            let sci: f64 = self.atol + y_i.abs() * self.rtol;
+            let f0_i = f0[i];
+            let f1_i = f1[i];
+            let y_i = self.y[i];
+            let sci = self.atol + y_i.abs() * self.rtol;
             d2 += ((f1_i - f0_i) / sci) * ((f1_i - f0_i) / sci);
         }
         d2 = d2.sqrt() / h0;
 
-        let h1 = if d1.sqrt().max(d2.abs()) <= 1.0E-15 {
-            (1.0E-6_f64).max(h0.abs() * 1.0E-3)
+        let h1 = if d1.sqrt().max(d2.abs()) <= T::from(1.0E-15).unwrap() {
+            T::from(1.0E-6_f64)
+                .unwrap()
+                .max(h0.abs() * T::from(1.0E-3).unwrap())
         } else {
-            (0.01 / (d1.sqrt().max(d2))).powf(1.0 / 8.0)
+            (T::from(0.01).unwrap() / (d1.sqrt().max(d2))).powf(T::one() / T::from(8.0).unwrap())
         };
 
         sign(
-            (100.0 * h0.abs()).min(h1.min(self.controller.h_max())),
+            (T::from(100.0).unwrap() * h0.abs()).min(h1.min(self.controller.h_max())),
             posneg,
         )
     }
@@ -245,13 +255,13 @@ where
         self.x_old = self.x;
         let mut n_step = 0;
         let mut last = false;
-        let mut h_new = 0.0;
+        let mut h_new = T::zero();
         let dim = rows.value();
         let mut iasti = 0;
         let mut non_stiff = 0;
-        let posneg = sign(1.0, self.x_end - self.x);
+        let posneg = sign(T::one(), self.x_end - self.x);
 
-        if self.h == 0.0 {
+        if self.h == T::zero() {
             self.h = self.hinit();
             self.stats.num_eval += 2;
         }
@@ -270,17 +280,22 @@ where
             // Check if step number is within allowed range
             if n_step >= self.n_max {
                 self.h_old = self.h;
-                return Err(IntegrationError::MaxNumStepReached { x: self.x, n_step });
+                return Err(IntegrationError::MaxNumStepReached {
+                    x: f64::from(self.x),
+                    n_step,
+                });
             }
 
             // Check for step size underflow
-            if 0.1 * self.h.abs() <= self.uround * self.x.abs() {
+            if T::from(0.1).unwrap() * self.h.abs() <= self.uround * self.x.abs() {
                 self.h_old = self.h;
-                return Err(IntegrationError::StepSizeUnderflow { x: self.x });
+                return Err(IntegrationError::StepSizeUnderflow {
+                    x: f64::from(self.x),
+                });
             }
 
             // Check if it's the last iteration
-            if (self.x + 1.01 * self.h - self.x_end) * posneg > 0.0 {
+            if (self.x + T::from(1.01).unwrap() * self.h - self.x_end) * posneg > T::zero() {
                 self.h = self.x_end - self.x;
                 last = true;
             }
@@ -291,13 +306,10 @@ where
             for s in 1..12 {
                 y_next = self.y.clone();
                 for (j, k_value) in k.iter().enumerate().take(s) {
-                    y_next += k_value
-                        * (self.h * dopri853::a::<f64>(s + 1, j + 1))
-                            .to_subset()
-                            .unwrap();
+                    y_next += k_value * (self.h * dopri853::a::<T>(s + 1, j + 1));
                 }
                 self.f.system(
-                    self.x + (self.h * dopri853::c::<f64>(s + 1)),
+                    self.x + (self.h * dopri853::c::<T>(s + 1)),
                     &y_next,
                     &mut k[s],
                 );
@@ -306,46 +318,46 @@ where
             k[2] = k[11].clone();
             self.stats.num_eval += 11;
 
-            k[3] = &k[0] * dopri853::b(1)
-                + &k[5] * dopri853::b(6)
-                + &k[6] * dopri853::b(7)
-                + &k[7] * dopri853::b(8)
-                + &k[8] * dopri853::b(9)
-                + &k[9] * dopri853::b(10)
-                + &k[1] * dopri853::b(11)
-                + &k[2] * dopri853::b(12);
-            k[4] = &self.y + &k[3] * self.h.to_subset().unwrap();
+            k[3] = &k[0] * dopri853::b::<T>(1)
+                + &k[5] * dopri853::b::<T>(6)
+                + &k[6] * dopri853::b::<T>(7)
+                + &k[7] * dopri853::b::<T>(8)
+                + &k[8] * dopri853::b::<T>(9)
+                + &k[9] * dopri853::b::<T>(10)
+                + &k[1] * dopri853::b::<T>(11)
+                + &k[2] * dopri853::b::<T>(12);
+            k[4] = &self.y + &k[3] * self.h;
 
             // Error estimate
             let mut err_est = OVector::zeros_generic(rows, cols);
             for (i, k_value) in k.iter().enumerate().take(12) {
-                err_est += k_value * dopri853::e(i + 1);
+                err_est += k_value * dopri853::e::<T>(i + 1);
             }
 
             // Compute error
-            let mut err = 0.0;
-            let mut err2 = 0.0;
+            let mut err = T::zero();
+            let mut err2 = T::zero();
             let err_bhh = &k[3]
-                - &k[0] * dopri853::bhh(1)
-                - &k[8] * dopri853::bhh(2)
-                - &k[2] * dopri853::bhh(3);
+                - &k[0] * dopri853::bhh::<T>(1)
+                - &k[8] * dopri853::bhh::<T>(2)
+                - &k[2] * dopri853::bhh::<T>(3);
             for i in 0..dim {
-                let y_i = f64::from(self.y[i]);
-                let k5_i = f64::from(k[4][i]);
+                let y_i = self.y[i];
+                let k5_i = k[4][i];
                 let sc_i = self.atol + y_i.abs().max(k5_i.abs()) * self.rtol;
 
-                let err_est_i = f64::from(err_est[i]);
+                let err_est_i = err_est[i];
                 err += (err_est_i / sc_i) * (err_est_i / sc_i);
 
-                let erri = f64::from(err_bhh[i]);
+                let erri = err_bhh[i];
                 err2 += (erri / sc_i) * (erri / sc_i);
             }
-            let mut deno = err + 0.01 * err2;
-            if deno <= 0.0 {
-                deno = 1.0;
+            let mut deno = err + T::from(0.01).unwrap() * err2;
+            if deno <= T::zero() {
+                deno = T::one();
             }
 
-            err = self.h.abs() * err * (1.0 / (deno * dim as f64)).sqrt();
+            err = self.h.abs() * err * (T::one() / (deno * T::from(dim).unwrap())).sqrt();
 
             // Step size control
             if self.controller.accept(err, self.h, &mut h_new) {
@@ -356,20 +368,22 @@ where
 
                 // Stifness detection
                 if self.stats.accepted_steps % self.n_stiff == 0 || iasti > 0 {
-                    let num = f64::from((&k[3] - &k[2]).dot(&(&k[3] - &k[2])));
-                    let den = f64::from((&k[4] - &y_next).dot(&(&k[4] - &y_next)));
-                    let h_lamb = if den > 0.0 {
+                    let num = T::from((&k[3] - &k[2]).dot(&(&k[3] - &k[2]))).unwrap();
+                    let den = T::from((&k[4] - &y_next).dot(&(&k[4] - &y_next))).unwrap();
+                    let h_lamb = if den > T::zero() {
                         self.h * (num / den).sqrt()
                     } else {
-                        0.0
+                        T::zero()
                     };
 
-                    if h_lamb > 6.1 {
+                    if h_lamb > T::from(6.1).unwrap() {
                         non_stiff = 0;
                         iasti += 1;
                         if iasti == 15 {
                             self.h_old = self.h;
-                            return Err(IntegrationError::StiffnessDetected { x: self.x });
+                            return Err(IntegrationError::StiffnessDetected {
+                                x: f64::from(self.x),
+                            });
                         }
                     } else {
                         non_stiff += 1;
@@ -380,7 +394,7 @@ where
                 }
 
                 if self.out_type == OutputType::Dense {
-                    let h = self.h.to_subset().unwrap();
+                    let h = self.h;
 
                     self.rcont[0] = self.y.clone();
                     let y_diff = &k[4] - &self.y;
@@ -391,75 +405,75 @@ where
                     for i in 4..8 {
                         self.rcont[i] = OVector::zeros_generic(rows, cols);
                         for j in 1..13 {
-                            self.rcont[i] += &k[j - 1] * dopri853::d(i, j);
+                            self.rcont[i] += &k[j - 1] * dopri853::d::<T>(i, j);
                         }
                     }
 
                     // Next three function evaluations
                     let mut y_next = &self.y
-                        + (&k[0] * dopri853::a(14, 1)
-                            + &k[6] * dopri853::a(14, 7)
-                            + &k[7] * dopri853::a(14, 8)
-                            + &k[8] * dopri853::a(14, 9)
-                            + &k[9] * dopri853::a(14, 10)
-                            + &k[1] * dopri853::a(14, 11)
-                            + &k[2] * dopri853::a(14, 12)
-                            + &k[3] * dopri853::a(14, 13))
+                        + (&k[0] * dopri853::a::<T>(14, 1)
+                            + &k[6] * dopri853::a::<T>(14, 7)
+                            + &k[7] * dopri853::a::<T>(14, 8)
+                            + &k[8] * dopri853::a::<T>(14, 9)
+                            + &k[9] * dopri853::a::<T>(14, 10)
+                            + &k[1] * dopri853::a::<T>(14, 11)
+                            + &k[2] * dopri853::a::<T>(14, 12)
+                            + &k[3] * dopri853::a::<T>(14, 13))
                             * h;
                     self.f
-                        .system(self.x + self.h * dopri853::c::<f64>(14), &y_next, &mut k[9]);
+                        .system(self.x + self.h * dopri853::c::<T>(14), &y_next, &mut k[9]);
 
                     y_next = &self.y
-                        + (&k[0] * dopri853::a(15, 1)
-                            + &k[5] * dopri853::a(15, 6)
-                            + &k[6] * dopri853::a(15, 7)
-                            + &k[7] * dopri853::a(15, 8)
-                            + &k[1] * dopri853::a(15, 11)
-                            + &k[2] * dopri853::a(15, 12)
-                            + &k[3] * dopri853::a(15, 13)
-                            + &k[9] * dopri853::a(15, 14))
+                        + (&k[0] * dopri853::a::<T>(15, 1)
+                            + &k[5] * dopri853::a::<T>(15, 6)
+                            + &k[6] * dopri853::a::<T>(15, 7)
+                            + &k[7] * dopri853::a::<T>(15, 8)
+                            + &k[1] * dopri853::a::<T>(15, 11)
+                            + &k[2] * dopri853::a::<T>(15, 12)
+                            + &k[3] * dopri853::a::<T>(15, 13)
+                            + &k[9] * dopri853::a::<T>(15, 14))
                             * h;
                     self.f
-                        .system(self.x + self.h * dopri853::c::<f64>(15), &y_next, &mut k[1]);
+                        .system(self.x + self.h * dopri853::c::<T>(15), &y_next, &mut k[1]);
 
                     y_next = &self.y
-                        + (&k[0] * dopri853::a(16, 1)
-                            + &k[5] * dopri853::a(16, 6)
-                            + &k[6] * dopri853::a(16, 7)
-                            + &k[7] * dopri853::a(16, 8)
-                            + &k[8] * dopri853::a(16, 9)
-                            + &k[3] * dopri853::a(16, 13)
-                            + &k[9] * dopri853::a(16, 14)
-                            + &k[1] * dopri853::a(16, 15))
+                        + (&k[0] * dopri853::a::<T>(16, 1)
+                            + &k[5] * dopri853::a::<T>(16, 6)
+                            + &k[6] * dopri853::a::<T>(16, 7)
+                            + &k[7] * dopri853::a::<T>(16, 8)
+                            + &k[8] * dopri853::a::<T>(16, 9)
+                            + &k[3] * dopri853::a::<T>(16, 13)
+                            + &k[9] * dopri853::a::<T>(16, 14)
+                            + &k[1] * dopri853::a::<T>(16, 15))
                             * h;
                     self.f
-                        .system(self.x + self.h * dopri853::c::<f64>(16), &y_next, &mut k[2]);
+                        .system(self.x + self.h * dopri853::c::<T>(16), &y_next, &mut k[2]);
 
                     self.stats.num_eval += 3;
 
                     self.rcont[4] = (&self.rcont[4]
-                        + &k[3] * dopri853::d(4, 13)
-                        + &k[9] * dopri853::d(4, 14)
-                        + &k[1] * dopri853::d(4, 15)
-                        + &k[2] * dopri853::d(4, 16))
+                        + &k[3] * dopri853::d::<T>(4, 13)
+                        + &k[9] * dopri853::d::<T>(4, 14)
+                        + &k[1] * dopri853::d::<T>(4, 15)
+                        + &k[2] * dopri853::d::<T>(4, 16))
                         * h;
                     self.rcont[5] = (&self.rcont[5]
-                        + &k[3] * dopri853::d(5, 13)
-                        + &k[9] * dopri853::d(5, 14)
-                        + &k[1] * dopri853::d(5, 15)
-                        + &k[2] * dopri853::d(5, 16))
+                        + &k[3] * dopri853::d::<T>(5, 13)
+                        + &k[9] * dopri853::d::<T>(5, 14)
+                        + &k[1] * dopri853::d::<T>(5, 15)
+                        + &k[2] * dopri853::d::<T>(5, 16))
                         * h;
                     self.rcont[6] = (&self.rcont[6]
-                        + &k[3] * dopri853::d(6, 13)
-                        + &k[9] * dopri853::d(6, 14)
-                        + &k[1] * dopri853::d(6, 15)
-                        + &k[2] * dopri853::d(6, 16))
+                        + &k[3] * dopri853::d::<T>(6, 13)
+                        + &k[9] * dopri853::d::<T>(6, 14)
+                        + &k[1] * dopri853::d::<T>(6, 15)
+                        + &k[2] * dopri853::d::<T>(6, 16))
                         * h;
                     self.rcont[7] = (&self.rcont[7]
-                        + &k[3] * dopri853::d(7, 13)
-                        + &k[9] * dopri853::d(7, 14)
-                        + &k[1] * dopri853::d(7, 15)
-                        + &k[2] * dopri853::d(7, 16))
+                        + &k[3] * dopri853::d::<T>(7, 13)
+                        + &k[9] * dopri853::d::<T>(7, 14)
+                        + &k[1] * dopri853::d::<T>(7, 15)
+                        + &k[2] * dopri853::d::<T>(7, 16))
                         * h;
                 }
 
@@ -498,15 +512,15 @@ where
     /// If a dense output is required, computes the solution and pushes it into the output vector. Else, pushes the solution into the output vector.
     fn solution_output(&mut self, y_next: OVector<T, D>) {
         if self.out_type == OutputType::Dense {
-            if (self.xd - self.x0).abs() < f64::EPSILON {
+            if (self.xd - self.x0).abs() < T::from(f64::EPSILON).unwrap() {
                 self.results.push(self.x0, self.y.clone());
                 self.xd += self.dx;
             } else {
                 while self.xd.abs() <= self.x.abs() {
                     if self.x_old.abs() <= self.xd.abs() && self.x.abs() >= self.xd.abs() {
                         let theta = (self.xd - self.x_old) / self.h_old;
-                        let theta1 = (1.0 - theta).to_subset().unwrap();
-                        let theta = theta.to_subset().unwrap();
+                        let theta1 = T::one() - theta;
+
                         let y_out = &self.rcont[0]
                             + (&self.rcont[1]
                                 + (&self.rcont[2]
@@ -531,7 +545,7 @@ where
     }
 
     /// Getter for the independent variable's output.
-    pub fn x_out(&self) -> &Vec<f64> {
+    pub fn x_out(&self) -> &Vec<T> {
         &self.results.get().0
     }
 
@@ -541,25 +555,24 @@ where
     }
 
     /// Getter for the results type, a pair of independent and dependent variables
-    pub fn results(&self) -> &SolverResult<OVector<T, D>> {
+    pub fn results(&self) -> &SolverResult<T, OVector<T, D>> {
         &self.results
     }
 }
 
-impl<T, D: Dim, F> Into<SolverResult<OVector<T, D>>> for Dop853<OVector<T, D>, F>
+impl<T, D: Dim, F> Into<SolverResult<T, OVector<T, D>>> for Dop853<T, OVector<T, D>, F>
 where
-    f64: From<T>,
-    T: Copy + SubsetOf<f64> + Scalar + ClosedAdd + ClosedMul + ClosedSub + Zero,
-    F: System<OVector<T, D>>,
+    T: FloatNumber,
+    F: System<T, OVector<T, D>>,
     DefaultAllocator: Allocator<T, D>,
 {
-    fn into(self) -> SolverResult<OVector<T, D>> {
+    fn into(self) -> SolverResult<T, OVector<T, D>> {
         self.results
     }
 }
 
-fn sign(a: f64, b: f64) -> f64 {
-    if b > 0.0 {
+fn sign<T: FloatNumber>(a: T, b: T) -> T {
+    if b > T::zero() {
         a.abs()
     } else {
         -a.abs()
@@ -574,7 +587,7 @@ mod tests {
 
     // Same as Test3 from rk4.rs, but aborts after x is greater/equal than 0.5
     struct Test1 {}
-    impl<D: Dim> System<OVector<f64, D>> for Test1
+    impl<D: Dim> System<f64, OVector<f64, D>> for Test1
     where
         DefaultAllocator: Allocator<f64, D>,
     {

--- a/src/dop_shared.rs
+++ b/src/dop_shared.rs
@@ -11,7 +11,7 @@ use thiserror::Error;
 /// The type parameter T should be either `f32` or `f64`, the trait [FloatNumber] is used
 /// internally to allow generic code.
 ///
-/// The type parameter V is a state vector. To have an easy start we recommend to use [nalgebra] vectors.
+/// The type parameter V is a state vector. To have an easy start it is recommend to use [nalgebra] vectors.
 /// ```rust
 /// // A predefined type for a vector (works from 1..6)
 /// type Precision = f64

--- a/src/dop_shared.rs
+++ b/src/dop_shared.rs
@@ -6,10 +6,25 @@ use simba::scalar::{ClosedAdd, ClosedDiv, ClosedMul, ClosedNeg, ClosedSub, Subse
 use std::fmt;
 use thiserror::Error;
 
-/// Trait needed to be implemented by the user.
+/// Trait needed to be implemented by the user
+///
+/// The type parameter T should be either `f32` or `f64`, the trait [FloatNumber] is used
+/// internally to allow generic code.
+///
+/// The type parameter V is a state vector. To have an easy start we recommend to use [nalgebra] vectors.
+/// ```rust
+/// // A predefined type for a vector (works from 1..6)
+/// type Precision = f64
+/// type State = Vector3<Precision>;
+/// type MySystem = System<Precision, State>
+///
+/// // Definition of a higher dimensional vector using nalgebra
+/// type AltState = SVector<Precision, 9>
+/// type MyAltSystem = System<Precision, State>
+/// ```
 pub trait System<T, V>
 where
-    T: SubsetOf<f64>,
+    T: FloatNumber,
 {
     /// System of ordinary differential equations.
     fn system(&self, x: T, y: &V, dy: &mut V);

--- a/src/dop_shared.rs
+++ b/src/dop_shared.rs
@@ -13,6 +13,47 @@ pub trait System<V> {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct SolverResult<V>(Vec<f64>, Vec<V>);
+
+impl<V> SolverResult<V> {
+    pub fn new(x: Vec<f64>, y: Vec<V>) -> Self {
+        SolverResult { 0: x, 1: y }
+    }
+
+    pub fn with_capacity(n: usize) -> Self {
+        SolverResult {
+            0: Vec::with_capacity(n),
+            1: Vec::with_capacity(n),
+        }
+    }
+
+    pub fn push(&mut self, x: f64, y: V) {
+        self.0.push(x);
+        self.1.push(y);
+    }
+
+    pub fn append(&mut self, mut other: SolverResult<V>) {
+        self.0.append(&mut other.0);
+        self.1.append(&mut other.1);
+    }
+
+    /// Returns a pair that contains references to the internal vectors
+    pub fn get(&self) -> (&Vec<f64>, &Vec<V>) {
+        (&self.0, &self.1)
+    }
+}
+
+/// default implementation starts with empty vectors for x and y
+impl<V> Default for SolverResult<V> {
+    fn default() -> Self {
+        Self {
+            0: Default::default(),
+            1: Default::default(),
+        }
+    }
+}
+
 /// Enumeration of the types of the integration output.
 #[derive(PartialEq, Eq)]
 pub enum OutputType {

--- a/src/dopri5.rs
+++ b/src/dopri5.rs
@@ -85,9 +85,9 @@ where
             rtol,
             atol,
             results: SolverResult::default(),
-            uround: T::from(f64::EPSILON).unwrap(),
-            h: T::from(0.).unwrap(),
-            h_old: T::from(0.).unwrap(),
+            uround: T::epsilon(),
+            h: T::zero(),
+            h_old: T::zero(),
             n_max: 100000,
             n_stiff: 1000,
             controller: Controller::default(x, x_end),
@@ -149,7 +149,7 @@ where
             f,
             x,
             xd: x,
-            x_old: T::from(0.0).unwrap(),
+            x_old: T::zero(),
             x_end,
             dx,
             y,
@@ -158,7 +158,7 @@ where
             results: SolverResult::default(),
             uround: T::from(f64::EPSILON).unwrap(),
             h,
-            h_old: T::from(0.0).unwrap(),
+            h_old: T::zero(),
             n_max,
             n_stiff,
             controller: Controller::new(
@@ -168,7 +168,7 @@ where
                 fac_min,
                 h_max,
                 safety_factor,
-                sign(T::from(1.0).unwrap(), x_end - x),
+                sign(T::one(), x_end - x),
             ),
             out_type,
             rcont: [
@@ -202,7 +202,8 @@ where
         }
 
         // Compute h0
-        let mut h0 = if d0 < T::from(1.0E-10).unwrap() || d1 < T::from(1.0E-10).unwrap() {
+        let tol = T::from(1.0E-10).unwrap();
+        let mut h0 = if d0 < tol || d1 < tol {
             T::from(1.0E-6).unwrap()
         } else {
             T::from(0.01).unwrap() * (d0 / d1).sqrt()
@@ -423,7 +424,6 @@ where
                 if self.x_old.abs() <= self.xd.abs() && self.x.abs() >= self.xd.abs() {
                     let theta = (self.xd - self.x_old) / self.h_old;
                     let theta1 = T::one() - theta;
-                    //let theta = theta.to_subset().unwrap();
                     let y_out = &self.rcont[0]
                         + (&self.rcont[1]
                             + (&self.rcont[2]
@@ -467,7 +467,7 @@ where
 }
 
 fn sign<T: FloatNumber>(a: T, b: T) -> T {
-    if b > T::from(0.).unwrap() {
+    if b > T::zero() {
         a.abs()
     } else {
         -a.abs()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,8 +15,8 @@ pub mod dop_shared;
 pub mod dopri5;
 pub mod rk4;
 
-pub use dop853::Dop853;
-pub use dopri5::Dopri5;
+//pub use dop853::Dop853;
+//pub use dopri5::Dopri5;
 pub use rk4::Rk4;
 
 pub use dop_shared::System;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,8 +15,8 @@ pub mod dop_shared;
 pub mod dopri5;
 pub mod rk4;
 
-//pub use dop853::Dop853;
-//pub use dopri5::Dopri5;
+pub use dop853::Dop853;
+pub use dopri5::Dopri5;
 pub use rk4::Rk4;
 
 pub use dop_shared::System;

--- a/src/rk4.rs
+++ b/src/rk4.rs
@@ -61,7 +61,7 @@ where
             k,
             buffer,
             step_size,
-            half_step: step_size / T::from_f32(2.).unwrap(),
+            half_step: step_size / T::from(2.).unwrap(),
             results: SolverResult::with_capacity(num_steps),
             stats: Stats::new(),
         }
@@ -123,7 +123,7 @@ where
             let two = T::from(2.).unwrap();
             *y_elem = *y_elem
                 + (self.k[0][idx] + self.k[1][idx] * two + self.k[2][idx] * two + self.k[3][idx])
-                    * (self.step_size / T::from_f32(6.).unwrap());
+                    * (self.step_size / T::from(6.).unwrap());
         }
 
         // Early abortion check

--- a/src/rk4.rs
+++ b/src/rk4.rs
@@ -1,16 +1,14 @@
 //! Explicit Runge-Kutta method of order 4 with fixed step size.
 
-use crate::dop_shared::{IntegrationError, SolverResult, Stats, System};
+use crate::dop_shared::{FloatNumber, IntegrationError, SolverResult, Stats, System};
 
-use nalgebra::{allocator::Allocator, DefaultAllocator, Dim, OVector, Scalar};
-use num_traits::{Float, FromPrimitive, NumCast, Zero};
-use simba::scalar::{ClosedAdd, ClosedDiv, ClosedMul, ClosedNeg, ClosedSub, SubsetOf};
+use nalgebra::{allocator::Allocator, DefaultAllocator, Dim, OVector};
 
 /// Structure containing the parameters for the numerical integration.
 pub struct Rk4<T, V, F>
 where
     F: System<T, V>,
-    T: SubsetOf<f64>,
+    T: FloatNumber,
 {
     f: F,
     x: T,
@@ -26,17 +24,7 @@ where
 
 impl<T, D: Dim, F> Rk4<T, OVector<T, D>, F>
 where
-    T: Float
-        + NumCast
-        + FromPrimitive
-        + SubsetOf<f64>
-        + Scalar
-        + ClosedAdd
-        + ClosedMul
-        + ClosedSub
-        + ClosedNeg
-        + ClosedDiv
-        + Zero,
+    T: FloatNumber,
     F: System<T, OVector<T, D>>,
     OVector<T, D>: std::ops::Mul<T, Output = OVector<T, D>>,
     DefaultAllocator: Allocator<T, D>,
@@ -132,7 +120,7 @@ where
         let mut y_new = self.y.clone();
 
         for (idx, y_elem) in y_new.iter_mut().enumerate() {
-            let two = NumCast::from(2.).unwrap();
+            let two = T::from(2.).unwrap();
             *y_elem = *y_elem
                 + (self.k[0][idx] + self.k[1][idx] * two + self.k[2][idx] * two + self.k[3][idx])
                     * (self.step_size / T::from_f32(6.).unwrap());
@@ -172,7 +160,7 @@ where
 
 impl<T, D: Dim, F> Into<SolverResult<T, OVector<T, D>>> for Rk4<T, OVector<T, D>, F>
 where
-    T: Copy + SubsetOf<f64>,
+    T: FloatNumber,
     F: System<T, OVector<T, D>>,
     DefaultAllocator: Allocator<T, D>,
 {


### PR DESCRIPTION
The changes in this pull request are:

- Use a data structure to store the `SolverResults` move result as suggested in #23 works.
- Overwork the code to support both f32 and f64. This fixes #20 
- Add a new example for a bouncing ball.

There have been many changes as the generic code needs us to write T::from(0.23).unwrap() for any number that is not zero or one. I did not find another solution but if someone knows a way to make the code a bit shorter I'm happy to hear about it.