### PR TITLE
Adhere to Clippy lints (missed some).

### DIFF
--- a/examples/bouncing_ball.rs
+++ b/examples/bouncing_ball.rs
@@ -85,7 +85,7 @@ impl ode_solvers::System<Time, State> for BouncingBall {
     }
 }
 
-pub fn save(times: &[Time], states: &Vec<State>, filename: &Path) {
+pub fn save(times: &[Time], states: &[State], filename: &Path) {
     // Create or open file
     if let Some(dir) = filename.parent() {
         if let Err(e) = create_dir_all(dir) {

--- a/examples/three_body_system_dvector.rs
+++ b/examples/three_body_system_dvector.rs
@@ -58,7 +58,7 @@ impl ode_solvers::System<f64, State> for ThreeBodyProblem {
     }
 }
 
-pub fn save(times: &Vec<Time>, states: &Vec<State>, filename: &Path) {
+pub fn save(times: &[Time], states: &[State], filename: &Path) {
     // Create or open file
     if let Some(dir) = filename.parent() {
         if let Err(e) = create_dir_all(dir) {


### PR DESCRIPTION
I've missed some changes to avoid all lints.

Can we have a new `0.5.0` release? I could use the latest `nalgebra` support. Thanks!