### PR TITLE
Add `set_output`

### DIFF
--- a/src/dop853.rs
+++ b/src/dop853.rs
@@ -191,6 +191,13 @@ where
         }
     }
 
+    /// Sets the output type
+    /// 
+    /// See [`OutputType`] for more details.
+    pub fn set_output(&mut self, out_type: OutputType) {
+        self.out_type = out_type;
+    }
+
     /// Computes the initial step size.
     fn hinit(&self) -> T {
         let (rows, cols) = self.y.shape_generic();
@@ -538,7 +545,7 @@ where
                 }
             }
         } else {
-            self.results.push(self.x0, y_next.clone());
+            self.results.push(self.x, y_next.clone());
         }
     }
 

--- a/src/dopri5.rs
+++ b/src/dopri5.rs
@@ -183,6 +183,13 @@ where
         }
     }
 
+    /// Sets the output type
+    /// 
+    /// See [`OutputType`] for more details.
+    pub fn set_output(&mut self, out_type: OutputType) {
+        self.out_type = out_type;
+    }
+
     /// Computes the initial step size
     fn hinit(&self) -> T {
         let (rows, cols) = self.y.shape_generic();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,3 +22,4 @@ pub use dopri5::Dopri5;
 pub use rk4::Rk4;
 
 pub use dop_shared::System;
+pub use dop_shared::OutputType;


### PR DESCRIPTION
Currently, the only way to set the output type for Dopri5 and Dopri853 is to use `from_params`. This pull request adds the ability to update the output type with `set_output` without requiring all of the inputs needed for `from_params`. 

The longer-terms solution is probably to make the input `dx` in `new` an option (`Option<f64>`) but that would be a breaking change. 